### PR TITLE
[fix]ページ親ID変更箇所変更

### DIFF
--- a/templates/internals/admin/page_form.html
+++ b/templates/internals/admin/page_form.html
@@ -106,8 +106,8 @@
 						<dd>
 							<select name="page[pid]">
 								<option value="">なし</option>
-								<!--{foreach from=$pages|smarty:nodefaults item='page'}-->
-								<option value="{$page.id}"{if $input.page.pid == $page.id} selected="selected"{/if} >{$page.id}</option>
+								<!--{foreach from=$parent_pages|smarty:nodefaults item='parent_page'}-->
+								<option value="{$parent_page.id}"{if $input.page.pid == $parent_page.id} selected="selected"{/if}>{$parent_page.id}</option>
 								<!--{/foreach}-->
 							</select>
 						</dd>


### PR DESCRIPTION
ページIDが存在するとき、ページ編集画面で子ページ以下の階層を排除