### PR TITLE
プラグインのセットアップ完了時の動作の修正

### DIFF
--- a/templates/plugins/setup.html
+++ b/templates/plugins/setup.html
@@ -20,7 +20,6 @@
 	</div>
 	<div id="content">
 		<h2>{$plugin_name}プラグインのセットアップ</h2>
-		<p>{$plugin_name}プラグインのセットアップを実行します。</p>
 		<!--{if $freo.query.error}-->
 		<ul class="attention">
 			<li>不正なアクセスです。</li>
@@ -35,6 +34,8 @@
 		<ul class="complete">
 			<li>{$plugin_name}プラグインのセットアップが完了しました。</li>
 		</ul>
+		<!--{else}-->
+		<p>{$plugin_name}プラグインのセットアップを実行します。</p>
 		<!--{/if}-->
 		<!--{if !$freo.query.exec == 'setup'}-->
 		<form action="{$freo.core.http_file}/{$plugin_id}/setup" method="post">

--- a/templates/plugins/setup.html
+++ b/templates/plugins/setup.html
@@ -36,6 +36,7 @@
 			<li>{$plugin_name}プラグインのセットアップが完了しました。</li>
 		</ul>
 		<!--{/if}-->
+		<!--{if !$freo.query.exec == 'setup'}-->
 		<form action="{$freo.core.http_file}/{$plugin_id}/setup" method="post">
 			<fieldset>
 				<legend>セットアップ実行フォーム</legend>
@@ -43,6 +44,7 @@
 				<p><input type="submit" value="セットアップ実行" /></p>
 			</fieldset>
 		</form>
+		<!--{/if}-->
 		<ul>
 			<li><a href="{$freo.core.http_file}">記事一覧画面を表示</a></li>
 			<li><a href="{if $freo.core.https_file}{$freo.core.https_file}{else}{$freo.core.http_file}{/if}/login">管理画面にログイン</a></li>


### PR DESCRIPTION
プラグインのセットアップを完了した際に、セットアップ実行フォームが表示されるのを修正しました。

さらに「○○プラグインのセットアップを実行します。」をエラー・完了時には表示しないようにもしています。