### PR TITLE
【修正】freoをphp7以上でエラーが起こらないように修正

### DIFF
--- a/libs/freo/common.php
+++ b/libs/freo/common.php
@@ -560,7 +560,7 @@ function freo_user()
 				freo_error($stmt->errorInfo());
 			}
 
-			freo_setcookie('freo[session]', null);
+			freo_setcookie('freo[session]', '');	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 		}
 
 		$freo->user = array(

--- a/libs/freo/initialize.php
+++ b/libs/freo/initialize.php
@@ -8,11 +8,9 @@
 
 *********************************************************************/
 
+//php7以上で削除されたini_setを削除 | holydragoonjp
 ini_set('default_charset', 'UTF-8');
-ini_set('mbstring.internal_encoding', 'UTF-8');
 ini_set('mbstring.language', 'Japanese');
-ini_set('mbstring.input_encoding', 'pass');
-ini_set('mbstring.output_encoding', 'pass');
 ini_set('mbstring.substitute_character', 'none');
 
 ini_set('session.use_trans_sid', 0);

--- a/libs/freo/internals/admin/entry_form.php
+++ b/libs/freo/internals/admin/entry_form.php
@@ -79,10 +79,10 @@ function freo_main()
 
 		//アップロードデータ初期化
 		if (!isset($_FILES['entry']['tmp_name']['file'])) {
-			$_FILES['entry']['tmp_name']['file'] = null;
+			$_FILES['entry']['tmp_name']['file'] = '';	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 		}
 		if (!isset($_FILES['entry']['tmp_name']['image'])) {
-			$_FILES['entry']['tmp_name']['image'] = null;
+			$_FILES['entry']['tmp_name']['image'] = '';	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 		}
 
 		$stmt = $freo->pdo->query('SELECT * FROM ' . FREO_DATABASE_PREFIX . 'options WHERE (target IS NULL OR target = \'entry\') AND type = \'file\' ORDER BY sort, id');

--- a/libs/freo/internals/admin/media.php
+++ b/libs/freo/internals/admin/media.php
@@ -36,32 +36,33 @@ function freo_main()
 	//親ディレクトリ取得
 	$path = $_GET['path'];
 
-	if (preg_match('/(.+)\/$/', $path, $matches)) {
-		$path = $matches[1];
-	}
-	$pos = strrpos($path, '/');
-
-	if ($pos > 0) {
-		$parent = substr($path, 0, $pos) . '/';
-	} else {
-		$parent = '';
-	}
-
-	//閲覧制限確認
+	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 	$restriction = false;
+	$parent      = '';
+	if ($path) {
+		if (preg_match('/(.+)\/$/', $path, $matches)) {
+			$path = $matches[1];
+		}
+		$pos = strrpos($path, '/');
 
-	$paths = explode('/', $path);
-
-	while (!empty($paths)) {
-		$path = implode('/', $paths);
-
-		if (file_exists(FREO_FILE_DIR . 'media_restrictions/' . $path . '.txt')) {
-			$restriction = true;
-
-			break;
+		if ($pos > 0) {
+			$parent = substr($path, 0, $pos) . '/';
 		}
 
-		array_pop($paths);
+		//閲覧制限確認
+		$paths = explode('/', $path);
+
+		while (!empty($paths)) {
+			$path = implode('/', $paths);
+
+			if (file_exists(FREO_FILE_DIR . 'media_restrictions/' . $path . '.txt')) {
+				$restriction = true;
+
+				break;
+			}
+
+			array_pop($paths);
+		}
 	}
 
 	//メディア取得

--- a/libs/freo/internals/admin/media_delete.php
+++ b/libs/freo/internals/admin/media_delete.php
@@ -31,51 +31,55 @@ function freo_main()
 		freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
 	}
 
-	if (empty($_GET['directory'])) {
-		//ファイル削除
-		if (!unlink(FREO_FILE_DIR . 'medias/' . $_GET['path'] . $_GET['name'])) {
-			freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
-		}
-
-		//サムネイル削除
-		if (file_exists(FREO_FILE_DIR . 'media_thumbnails/' . $_GET['path'] . $_GET['name'])) {
-			if (!unlink(FREO_FILE_DIR . 'media_thumbnails/' . $_GET['path'] . $_GET['name'])) {
+	if (isset($_GET['name'])) {	//$_GET['name']がnullで$_GET['path']までnullだとmedias/フォルダなどが削除されてしまうため、その回避策 | holydragoonjp
+		if (empty($_GET['directory'])) {
+			//ファイル削除
+			if (!unlink(FREO_FILE_DIR . 'medias/' . $_GET['path'] . $_GET['name'])) {
 				freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
 			}
-		}
 
-		//ファイルの説明削除
-		if (file_exists(FREO_FILE_DIR . 'media_memos/' . $_GET['path'] . $_GET['name'] . '.txt')) {
-			if (!unlink(FREO_FILE_DIR . 'media_memos/' . $_GET['path'] . $_GET['name'] . '.txt')) {
+			//サムネイル削除
+			if (file_exists(FREO_FILE_DIR . 'media_thumbnails/' . $_GET['path'] . $_GET['name'])) {
+				if (!unlink(FREO_FILE_DIR . 'media_thumbnails/' . $_GET['path'] . $_GET['name'])) {
+					freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
+				}
+			}
+
+			//ファイルの説明削除
+			if (file_exists(FREO_FILE_DIR . 'media_memos/' . $_GET['path'] . $_GET['name'] . '.txt')) {
+				if (!unlink(FREO_FILE_DIR . 'media_memos/' . $_GET['path'] . $_GET['name'] . '.txt')) {
+					freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
+				}
+			}
+		} else {
+			//ディレクトリ削除
+			if (!freo_rmdir(FREO_FILE_DIR . 'medias/' . $_GET['path'] . $_GET['name'])) {
+				freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
+			}
+
+			//サムネイル用ディレクトリ削除
+			if (!freo_rmdir(FREO_FILE_DIR . 'media_thumbnails/' . $_GET['path'] . $_GET['name'])) {
+				freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
+			}
+
+			//ファイルの説明用ディレクトリ削除
+			if (!freo_rmdir(FREO_FILE_DIR . 'media_memos/' . $_GET['path'] . $_GET['name'])) {
+				freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
+			}
+
+			//閲覧制限削除
+			if (file_exists(FREO_FILE_DIR . 'media_restrictions/' . $_GET['path'] . preg_replace('/\/$/', '', $_GET['name']) . '.txt')) {
+				if (!unlink(FREO_FILE_DIR . 'media_restrictions/' . $_GET['path'] . preg_replace('/\/$/', '', $_GET['name']) . '.txt')) {
+					freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
+				}
+			}
+
+			if (!freo_rmdir(FREO_FILE_DIR . 'media_restrictions/' . $_GET['path'] . $_GET['name'])) {
 				freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
 			}
 		}
 	} else {
-		//ディレクトリ削除
-		if (!freo_rmdir(FREO_FILE_DIR . 'medias/' . $_GET['path'] . $_GET['name'])) {
-			freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
-		}
-
-		//サムネイル用ディレクトリ削除
-		if (!freo_rmdir(FREO_FILE_DIR . 'media_thumbnails/' . $_GET['path'] . $_GET['name'])) {
-			freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
-		}
-
-		//ファイルの説明用ディレクトリ削除
-		if (!freo_rmdir(FREO_FILE_DIR . 'media_memos/' . $_GET['path'] . $_GET['name'])) {
-			freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
-		}
-
-		//閲覧制限削除
-		if (file_exists(FREO_FILE_DIR . 'media_restrictions/' . $_GET['path'] . preg_replace('/\/$/', '', $_GET['name']) . '.txt')) {
-			if (!unlink(FREO_FILE_DIR . 'media_restrictions/' . $_GET['path'] . preg_replace('/\/$/', '', $_GET['name']) . '.txt')) {
-				freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
-			}
-		}
-
-		if (!freo_rmdir(FREO_FILE_DIR . 'media_restrictions/' . $_GET['path'] . $_GET['name'])) {
-			freo_redirect('admin/media?error=1' . (isset($_GET['type']) ? '&type=' . $_GET['type'] : ''));
-		}
+		freo_error('不正なアクセスです。');
 	}
 
 	//ログ記録

--- a/libs/freo/internals/admin/page_form.php
+++ b/libs/freo/internals/admin/page_form.php
@@ -87,10 +87,10 @@ function freo_main()
 
 		//アップロードデータ初期化
 		if (!isset($_FILES['page']['tmp_name']['file'])) {
-			$_FILES['page']['tmp_name']['file'] = null;
+			$_FILES['page']['tmp_name']['file'] = '';	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 		}
 		if (!isset($_FILES['page']['tmp_name']['image'])) {
-			$_FILES['page']['tmp_name']['image'] = null;
+			$_FILES['page']['tmp_name']['image'] = '';	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 		}
 
 		$stmt = $freo->pdo->query('SELECT * FROM ' . FREO_DATABASE_PREFIX . 'options WHERE (target IS NULL OR target = \'page\') AND type = \'file\' ORDER BY sort, id');

--- a/libs/freo/internals/comment/post.php
+++ b/libs/freo/internals/comment/post.php
@@ -100,10 +100,11 @@ function freo_main()
 		freo_setcookie('comment[url]',     $comment['url'],     time() + FREO_COOKIE_EXPIRE);
 		freo_setcookie('comment[session]', $comment['session'], time() + FREO_COOKIE_EXPIRE);
 	} else {
-		freo_setcookie('comment[name]',    null);
-		freo_setcookie('comment[mail]',    null);
-		freo_setcookie('comment[url]',     null);
-		freo_setcookie('comment[session]', null);
+		//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
+		freo_setcookie('comment[name]',    '');
+		freo_setcookie('comment[mail]',    '');
+		freo_setcookie('comment[url]',     '');
+		freo_setcookie('comment[session]', '');
 	}
 
 	//入力データ破棄

--- a/libs/freo/internals/file/default.php
+++ b/libs/freo/internals/file/default.php
@@ -392,7 +392,7 @@ function freo_main()
 		} elseif (file_exists(FREO_FILE_DIR . 'medias/' . $_GET['path'])) {
 			$filename = FREO_FILE_DIR . 'medias/' . $_GET['path'];
 		} else {
-			$filename = null;
+			$filename = '';	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 		}
 	}
 

--- a/libs/freo/pictogram.php
+++ b/libs/freo/pictogram.php
@@ -27,7 +27,11 @@ function freo_pictogram_unify($data)
 			$translations = array_flip($translations);
 		}
 
-		$data = preg_replace('/\[e:([^\]]+)\]/e', '$translations[pack("H*","$1")]', $data);
+		$data = preg_replace_callback('/\[e:([^\]]+)\]/',
+			function ($m) {
+				return '$translations[pack("H*", "' . $m[1] . '")]';
+			},
+			$data);	//php7.0 e修飾子削除 対応 | holydragoonjp
 	}
 
 	return $data;
@@ -52,8 +56,16 @@ function freo_pictogram_convert($data)
 
 		$data = freo_pictogram_escape($data);
 		$data = str_replace('$', $temporary, $data);
-		$data = preg_replace('/(value="([^"\\\\]|\\\\.)*")/e', 'freo_pictogram_unescape("$1","text")', $data);
-		$data = preg_replace('/(<textarea [^>]+>[^<]+<\/textarea>)/e', 'freo_pictogram_unescape("$1","text")', $data);
+		$data = preg_replace_callback('/(value="([^"\\\\]|\\\\.)*")/',
+			function ($m) {
+				return freo_pictogram_unescape($m[1], "text");
+			},
+			$data);	//php7.0 e修飾子削除 対応 | holydragoonjp
+		$data = preg_replace_callback('/(<textarea [^>]+>[^<]+<\/textarea>)/',
+			function ($m) {
+				return freo_pictogram_unescape($m[1], "text");
+			},
+			$data);
 		$data = str_replace($temporary, '$', $data);
 		$data = freo_pictogram_unescape($data);
 	}
@@ -81,7 +93,11 @@ function freo_pictogram_except($data)
 /* 絵文字をエスケープ */
 function freo_pictogram_escape($data)
 {
-	return preg_replace('/<img class="emoji" src="([^"]+)" alt="" width="12" height="12" \/>/e', '"[E:".basename("$1",".gif")."]"', $data);
+	return preg_replace_callback('/<img class="emoji" src="([^"]+)" alt="" width="12" height="12" \/>/',
+		function ($m) {
+			return '"[E:".basename("' . $m[1] . '",".gif")."]"';
+		},
+		$data);	//php7.0 e修飾子削除 対応 | holydragoonjp
 }
 
 /* 絵文字をアンエスケープ */
@@ -90,7 +106,11 @@ function freo_pictogram_unescape($data, $type = 'html')
 	if ($type == 'html') {
 		return preg_replace('/\[E:([^\]]+)\]/', '<img class="emoji" src="' . FREO_PICTOGRAM_IMAGE_URL . '$1.gif" alt="" width="12" height="12" />', $data);
 	} else {
-		return preg_replace('/\[E:([^\]]+)\]/e', '"[e:".basename("$1",".gif")."]"', $data);
+		return preg_replace_callback('/\[E:([^\]]+)\]/',
+			function ($m) {
+				return '"[e:".basename("' . $m[1] . '",".gif")."]"';
+			},
+			$data);	//php7.0 e修飾子削除 対応 | holydragoonjp
 	}
 }
 

--- a/libs/freo/plugins/display.entry_calender.php
+++ b/libs/freo/plugins/display.entry_calender.php
@@ -21,7 +21,7 @@ function freo_display_entry_calender()
 	if (isset($_GET['date'])) {
 		$date = $_GET['date'];
 	} else {
-		$date = null;
+		$date = date('Ymd');	//php8.1 Deprecate passing null to non-nullable arguments of internal functions 対応 | holydragoonjp
 	}
 
 	if (preg_match('/^(\d\d\d\d)$/', $date, $matches)) {
@@ -70,7 +70,7 @@ function freo_display_entry_calender()
 	}
 	$stmt->bindValue(':now1',  date('Y-m-d H:i:s'));
 	$stmt->bindValue(':now2',  date('Y-m-d H:i:s'));
-	$stmt->bindValue(':month', $year . $month);
+	$stmt->bindValue(':month', $year . sprintf('%02d', $month));	//年単位の表示（http://freoを設置したurl/index.php/entry?date=2021 等）をすると、記事へのリンクが表示されない不具合への対応 | holydragoonjp
 	$flag = $stmt->execute();
 	if (!$flag) {
 		freo_error($stmt->errorInfo());

--- a/libs/freo/transfer.php
+++ b/libs/freo/transfer.php
@@ -23,11 +23,21 @@ function freo_transfer_execute($data)
 	$temporary = md5(uniqid(rand(), true));
 
 	$data = str_replace('$', $temporary, $data);
-	$data = preg_replace('/href="(([^"\\\\]|\\\\.)*)"/e', '"href=\"".freo_transfer_link("$1")."\""', $data);
-	$data = preg_replace('/src="(([^"\\\\]|\\\\.)*)"/e', '"src=\"".freo_transfer_link("$1")."\""', $data);
-	$data = preg_replace('/(<form [^>]+>)/e', 'freo_transfer_form("$1")', $data);
-	$data = str_replace($temporary, '$', $data);
-
+	$data = preg_replace_callback('/href="(([^"\\\\]|\\\\.)*)"/',	//php7.0 e修飾子削除 対応 | holydragoonjp
+		function ($m) {
+			return 'href="' . freo_transfer_link($m[1]) . '"';
+		},
+		$data);
+	$data = preg_replace_callback('/src="(([^"\\\\]|\\\\.)*)"/',
+		function ($m) {
+			return 'src="' . freo_transfer_link($m[1]) . '"';
+		},
+		$data);
+	$data = preg_replace_callback('/(<form [^>]+>)/',
+		function ($m) {
+			return freo_transfer_form($m[1]);
+		},
+		$data);
 	return $data;
 }
 


### PR DESCRIPTION
freoをphp7以上（ローカルサーバー上のxamppのphp8.1.0、display_errors=Onの環境）で各種エラーが表示された箇所を差し当たりエラーが出ないように修正しました。
しかし、php8.1で追加された『Deprecate passing null to non-nullable arguments of internal functions』の非推奨エラーに関しては、影響範囲があまりにも広すぎるため、エラーの出る箇所がまだ残っているかもしれません。